### PR TITLE
Fix Matomo Tag Manager Preview Mode

### DIFF
--- a/src/themes/seatable/layouts/_default/baseof.html
+++ b/src/themes/seatable/layouts/_default/baseof.html
@@ -310,10 +310,13 @@
             });
 
             const redirect = (url) => {
+                // Strip query parameters in order to not take them into account when comparing URLs
+                const currentUrl = window.location.href.split('?')[0];
+
                 // Redirect if the user is not already on the correct page
-                if (window.location.href !== url) {
-                    // Keep the URL fragment
-                    window.location.href = url + window.location.hash;
+                if (currentUrl !== url) {
+                    // Keep query parameters and URL fragment
+                    window.location.href = url + window.location.search + window.location.hash;
                 }
             };
         </script>

--- a/src/themes/seatable/layouts/_default/baseof.html
+++ b/src/themes/seatable/layouts/_default/baseof.html
@@ -275,6 +275,11 @@
                     return;
                 }
 
+                // Do not redirect if Matomo preview mode is enabled
+                if (params.has('mtmPreviewMode')) {
+                    return;
+                }
+
                 // Check local storage first
                 const language = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY));
 

--- a/src/themes/seatable/layouts/partials/head/js.html
+++ b/src/themes/seatable/layouts/partials/head/js.html
@@ -15,6 +15,13 @@
         // Enable debug mode (logs everything to the browser console)
         window._mtm = window._mtm || [];
         window._mtm.push(['enableDebugMode']);
+
+        // Enable preview mode
+        // TODO: Check why this does not work with the MTM query parameters
+        // Issue: Hugo automatically refreshes the page, which causes the query parameters to be gone and the cookie won't be set
+        // Workaround: Manually set the cookie
+        const containerId = 'g4kOtYep';
+        document.cookie = `mtmPreviewMode=mtmPreview6_${containerId}%3D1; max-age=3600; path=/; domain=localhost; SameSite=Lax; Secure`;
     </script>
 {{- else -}}
     <!-- Matomo Tag Manager (production environment) -->

--- a/src/themes/seatable/layouts/partials/head/js.html
+++ b/src/themes/seatable/layouts/partials/head/js.html
@@ -15,13 +15,6 @@
         // Enable debug mode (logs everything to the browser console)
         window._mtm = window._mtm || [];
         window._mtm.push(['enableDebugMode']);
-
-        // Enable preview mode
-        // TODO: Check why this does not work with the MTM query parameters
-        // Issue: Hugo automatically refreshes the page, which causes the query parameters to be gone and the cookie won't be set
-        // Workaround: Manually set the cookie
-        const containerId = 'g4kOtYep';
-        document.cookie = `mtmPreviewMode=mtmPreview6_${containerId}%3D1; max-age=3600; path=/; domain=localhost; SameSite=Lax; Secure`;
     </script>
 {{- else -}}
     <!-- Matomo Tag Manager (production environment) -->


### PR DESCRIPTION
Preview mode must be started inside Matomo's tag manager in order for this to work.

The console state is not persisted across page reloads, so link triggers can only be debugged by executing a right click on the button :(  

Related:
- https://forum.matomo.org/t/matomo-tag-manager-preview-debug/55643
- https://forum.matomo.org/t/using-preview-mode/50057